### PR TITLE
handle out of range negative indices

### DIFF
--- a/rscel/src/tests/neg_index_tests.rs
+++ b/rscel/src/tests/neg_index_tests.rs
@@ -18,3 +18,14 @@ fn test_neg_index() {
         assert!(ctx.exec("test2", &bindings).is_err());
     }
 }
+
+#[test]
+fn test_neg_index_out_of_range() {
+    let mut ctx = CelContext::new();
+    let bindings = BindContext::new();
+
+    ctx.add_program_str("test", "[1,2,3][-4]")
+        .expect("Failed to compile program");
+
+    assert!(ctx.exec("test", &bindings).is_err());
+}

--- a/rscel/src/types/cel_value.rs
+++ b/rscel/src/types/cel_value.rs
@@ -570,15 +570,23 @@ impl CelValue {
                                 }
                             } + (index as isize);
 
-                            if adjusted_index < 0
-                                || TryInto::<usize>::try_into(adjusted_index).unwrap() >= list.len()
-                            {
+                            let adjusted_index_usize =
+                                match TryInto::<usize>::try_into(adjusted_index) {
+                                    Ok(v) => v,
+                                    Err(_) => {
+                                        return CelValue::from_err(CelError::value(
+                                            "List access out of bounds 3",
+                                        ))
+                                    }
+                                };
+
+                            if adjusted_index < 0 || adjusted_index_usize >= list.len() {
                                 return CelValue::from_err(CelError::value(
                                     "List access out of bounds 3",
                                 ));
                             }
 
-                            list[adjusted_index as usize].clone()
+                            list[adjusted_index_usize].clone()
                         } else {
                             return CelValue::from_err(CelError::value(
                                 "Negative index is not allowed",


### PR DESCRIPTION
## Summary
- handle `TryInto` failures for negative list indices instead of unwrapping
- test out-of-range negative index access

## Testing
- `cargo +nightly-2025-08-08 test`
- `cargo +nightly-2025-08-08 test --no-default-features`


------
https://chatgpt.com/codex/tasks/task_e_689f6e7966e8832585b438c0688bb35a