### PR TITLE
feat: add SQL compiler stub

### DIFF
--- a/rscel/src/lib.rs
+++ b/rscel/src/lib.rs
@@ -55,6 +55,7 @@ mod compiler;
 mod context;
 mod interp;
 mod program;
+mod sql;
 mod types;
 
 // Export some public interface
@@ -66,6 +67,7 @@ pub use compiler::{
 pub use context::{BindContext, CelContext, RsCelFunction, RsCelMacro};
 pub use interp::ByteCode;
 pub use program::{Program, ProgramDetails};
+pub use sql::{SqlCompiler, SqlFragment, ToSql};
 pub use types::{CelError, CelResult, CelValue, CelValueDyn};
 
 // Some re-exports to allow a consistent use of serde

--- a/rscel/src/sql/mod.rs
+++ b/rscel/src/sql/mod.rs
@@ -1,0 +1,42 @@
+//! SQL compilation utilities.
+//!
+//! This module provides a minimal interface for converting CEL
+//! expressions into SQL fragments consisting of SQL text and a list
+//! of bound parameters.
+
+use crate::{AstNode, CelValue, Expr};
+
+/// SQL text and its associated parameter values.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SqlFragment {
+    /// The SQL text with placeholders for parameters.
+    pub sql: String,
+    /// Values bound to the placeholders within `sql`.
+    pub params: Vec<CelValue>,
+}
+
+/// Compiler that converts CEL AST nodes into SQL fragments.
+pub struct SqlCompiler;
+
+impl SqlCompiler {
+    /// Compile a CEL expression AST into a [`SqlFragment`].
+    pub fn compile(ast: &AstNode<Expr>) -> SqlFragment {
+        let compiler = SqlCompiler;
+        ast.to_sql(&compiler)
+    }
+}
+
+/// Trait for converting a type into a [`SqlFragment`].
+pub trait ToSql {
+    /// Convert `self` into a [`SqlFragment`] using the provided compiler.
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment;
+}
+
+impl ToSql for AstNode<Expr> {
+    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
+        SqlFragment {
+            sql: String::new(),
+            params: Vec::new(),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new `sql` module with `SqlCompiler`, `SqlFragment` and `ToSql`
- expose `SqlCompiler` API from crate root

## Testing
- `cargo +nightly-2025-08-08 test`
- `cargo +nightly-2025-08-08 test --no-default-features`


------
https://chatgpt.com/codex/tasks/task_e_689f7d5664488325a785f2dbaf169e3e