### PR TITLE
docs: add SQL compile example and assumptions

### DIFF
--- a/rscel/README.md
+++ b/rscel/README.md
@@ -1,0 +1,35 @@
+# rscel
+
+This crate provides the core implementation of the rscel CEL interpreter.
+
+## SQL compilation
+
+The `SqlCompiler` converts CEL abstract syntax trees (ASTs) into SQL fragments that can be executed in PostgreSQL.
+
+```rust
+use rscel::{Program, SqlCompiler, CelValue};
+
+let program = Program::from_source("1 + 2").unwrap();
+let ast = program.ast().unwrap();
+let frag = SqlCompiler::compile(ast).unwrap();
+
+assert_eq!(frag.sql, "($1 + $2)");
+assert_eq!(frag.params, vec![CelValue::from_int(1), CelValue::from_int(2)]);
+```
+
+This produces:
+
+```
+SQL: ($1 + $2)
+Params: [CelValue::from_int(1), CelValue::from_int(2)]
+```
+
+## Testing
+
+Run the full test suite before committing:
+
+```bash
+cargo +nightly-2025-08-08 test
+cargo +nightly-2025-08-08 test --no-default-features
+```
+

--- a/rscel/src/sql/mod.rs
+++ b/rscel/src/sql/mod.rs
@@ -4,13 +4,16 @@
 //! expressions into SQL fragments consisting of SQL text and a list
 //! of bound parameters.
 //!
-//! # JSON assumptions
+//! # PostgreSQL and JSON assumptions
 //!
-//! The generated SQL targets PostgreSQL `jsonb` values. Field and array
-//! accesses are translated into `jsonb` operator chains (`->` and `->>`),
-//! with the final segment in a chain extracted using `->>` to produce a
-//! text value. Array indices use `jsonb` subscripting. The JSON documents
-//! are assumed to contain the referenced structure at runtime.
+//! Generated SQL is intended for PostgreSQL. CEL variables are assumed
+//! to map to `jsonb` columns, and field or array accesses are translated
+//! into chains of the `->` and `->>` operators with the final segment
+//! extracted using `->>` to produce a text value. Array indices use
+//! `jsonb` subscripting. Literal values become numbered placeholders
+//! (`$1`, `$2`, ...), which should be bound in prepared statements. The
+//! referenced JSON structure is expected to exist at runtime; missing
+//! fields result in `NULL` values.
 
 use regex::Regex;
 use std::fmt;


### PR DESCRIPTION
## Summary
- add README with `SqlCompiler::compile` demonstration and testing instructions
- document PostgreSQL `jsonb` assumptions in `sql` module

## Testing
- `cargo +nightly-2025-08-08 test`
- `cargo +nightly-2025-08-08 test --no-default-features`


------
https://chatgpt.com/codex/tasks/task_e_689f918811a083258b20e144322ba9f1