### PR TITLE
docs: unwrap README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ let mut exec_ctx = BindContext::new();
 ctx.add_program_str("main", "p.x + 3").unwrap();
 exec_ctx.bind_protobuf_msg("p", p);
 
-assert_eq!(ctx.exec("main", &exec_ctx), 7.into());
+assert_eq!(ctx.exec("main", &exec_ctx).unwrap(), 7.into());
   
 ```
 


### PR DESCRIPTION
## Summary
- fix README protobuf example to unwrap result before asserting

## Testing
- `cargo +nightly-2025-08-08 test`
- `cargo +nightly-2025-08-08 test --no-default-features`


------
https://chatgpt.com/codex/tasks/task_e_689f9ca481ec83258b2590bd240aa75f