### PR TITLE
Add pyproject for Python package

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["maturin>=1,<2"]
+build-backend = "maturin"
+
+[project]
+name = "rscel"
+version = "1.0.6"
+description = "Python bindings for the rscel package"
+readme = "../README.md"
+license = { file = "../LICENSE" }
+requires-python = ">=3.9"
+authors = [{ name = "rscel developers" }]
+


### PR DESCRIPTION
## Summary
- define maturin build backend for Python bindings

## Testing
- `cargo +nightly-2025-08-08 test`
- `cargo +nightly-2025-08-08 test --no-default-features`
- `RUSTUP_TOOLCHAIN=nightly-2025-08-08 make run-python-tests`


------
https://chatgpt.com/codex/tasks/task_e_689f9e8368808325b703c0550b60bd32