### PR TITLE
docs: update test instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,8 @@ This repository provides a Rust implementation of the [CEL](https://github.com/g
 - Follow standard Rust naming conventions (`snake_case` for functions/variables, `CamelCase` for types).
 
 ## Testing
-- Run the full Rust test suite before committing:
-  - `cargo +nightly-2025-08-08 test`
-  - `cargo +nightly-2025-08-08 test --no-default-features`
+- Before committing, run the complete test suite with `make run-all-tests`.
+- The repository's `rust-toolchain.toml` pins the nightly toolchain, so `cargo test` automatically uses the correct version.
 - If your changes affect the Python bindings or tests, rebuild the wheel and run the Python tests:
   - `make run-python-tests`
 - For WebAssembly changes, run `make run-wasm-tests`.


### PR DESCRIPTION
## Summary
- recommend `make run-all-tests` as the primary check in AGENTS.md
- note the pinned nightly toolchain ensures `cargo test` uses the right version

## Testing
- `make run-all-tests` *(fails: failed to download wasm-opt binary)*

------
https://chatgpt.com/codex/tasks/task_e_689f9e74a2608325a1c9f6c70e60de6a